### PR TITLE
Add appcues

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -11,6 +11,9 @@
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
   })(window,document,'script','dataLayer','GTM-MSWJMNX');</script>
   <!-- End Dev GTM -->
+  <!-- Appcues-->
+    <script src="//fast.appcues.com/148149.js"></script>
+  <!--End Appcues-->
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -18,6 +18,18 @@ import { theme } from "./Theme";
 import { createLedgerContext } from "@daml/react";
 import { MainScreen } from "./components/MainScreen/MainScreen";
 
+// Needed for appcues
+// https://docs.appcues.com/en_US/366344-installation-developers
+declare global {
+  interface Window {
+      Appcues: any;
+  }
+}
+declare global {
+  interface Window {
+      AppcuesSettings: any;
+  }
+}
 // Context for the party of the user.
 export const userContext = createLedgerContext();
 // Context for the public party used to query user aliases.

--- a/ui/src/pages/LoginPage.tsx
+++ b/ui/src/pages/LoginPage.tsx
@@ -66,6 +66,10 @@ export const LoginPage: React.FC<Props> = ({ onLogin }) => {
   const login = useCallback(
     async (credentials: Credentials) => {
       onLogin(credentials);
+      window.Appcues?.identify(credentials.party, {
+        user: credentials.user,
+        party: credentials.party,
+    });
     },
     [onLogin]
   );


### PR DESCRIPTION
This should allow appcues be part of the deployed wallet sample app. 

This is a request from David Richards, to be able to add overlayed walk through into the sample app. 

<img width="1478" alt="Screenshot 2024-05-06 at 3 19 03 PM" src="https://github.com/digital-asset/wallet-sample-app/assets/97971317/b3a7b00c-aa15-4159-8d82-25a3230b995b">
